### PR TITLE
List page and nav fixes

### DIFF
--- a/projects/app-open-ziti/src/app/app-routing.module.ts
+++ b/projects/app-open-ziti/src/app/app-routing.module.ts
@@ -145,6 +145,11 @@ const routes: Routes = [
     canActivate: [authenticationGuard],
   },
   {
+    path: 'custom-fields',
+    component: ZacWrapperComponent,
+    canActivate: [authenticationGuard],
+  },
+  {
     path: '**',
     component: PageNotFoundComponent,
     pathMatch: 'full'

--- a/projects/app-open-ziti/src/app/app-urls.constants.ts
+++ b/projects/app-open-ziti/src/app/app-urls.constants.ts
@@ -22,5 +22,6 @@ export const URLS = {
     ZITI_PROFILE: '/profile',
     ZITI_SERVERS: '/servers',
     ZITI_SETTINGS: '/settings',
+    ZITI_CUSTOM_FIELDS: '/custom-fields',
     ZAC_LOGIN: '/login'
 };

--- a/projects/open-ziti-console-lib/src/lib/assets/data/settings.json
+++ b/projects/open-ziti-console-lib/src/lib/assets/data/settings.json
@@ -21,5 +21,6 @@
         }
     },
     "from": "",
-    "to": ""
+    "to": "",
+    "useNodeServer": true
 }

--- a/projects/open-ziti-console-lib/src/lib/features/data-table/data-table.component.html
+++ b/projects/open-ziti-console-lib/src/lib/features/data-table/data-table.component.html
@@ -1,4 +1,4 @@
-<div class="data-table-container" *ngIf="filterApplied || rowData?.length > 0;else nodata">
+<div class="data-table-container" *ngIf="filterApplied || rowData?.length > 0">
     <lib-table-filter-bar
             [startCount]="startCount"
             [endCount]="endCount"
@@ -120,8 +120,11 @@
     </p-calendar>
 </div>
 
-<ng-template #nodata>
-    <div class="flex-wrapper" *ngIf="false">
-        <div class="empty-table"><span>{{emptyMsg}}</span></div>
-    </div>
-</ng-template>
+<lib-no-items
+    #noitems
+    *ngIf="!filterApplied && rowData?.length <= 0"
+    (clickEmit)="openCreate()"
+    [image]="'No_Clients'"
+    [isEmpty]="rowData.length === 0"
+    [typeName]="'Identities'"
+></lib-no-items>

--- a/projects/open-ziti-console-lib/src/lib/features/data-table/data-table.component.html
+++ b/projects/open-ziti-console-lib/src/lib/features/data-table/data-table.component.html
@@ -1,4 +1,4 @@
-<div class="data-table-container" *ngIf="filterApplied || rowData?.length > 0">
+<div class="data-table-container" *ngIf="filterApplied || rowData?.length > 0;else nodata">
     <lib-table-filter-bar
             [startCount]="startCount"
             [endCount]="endCount"
@@ -120,11 +120,11 @@
     </p-calendar>
 </div>
 
-<lib-no-items
-    #noitems
-    *ngIf="!filterApplied && rowData?.length <= 0"
-    (clickEmit)="openCreate()"
-    [image]="'No_Clients'"
-    [isEmpty]="rowData.length === 0"
-    [typeName]="'Identities'"
-></lib-no-items>
+<ng-template #nodata>
+    <lib-no-items
+        (clickEmit)="openCreate()"
+        [image]="'No_Clients'"
+        [isEmpty]="rowData.length === 0"
+        [typeName]="'Identities'"
+    ></lib-no-items>
+</ng-template>

--- a/projects/open-ziti-console-lib/src/lib/features/data-table/data-table.component.ts
+++ b/projects/open-ziti-console-lib/src/lib/features/data-table/data-table.component.ts
@@ -44,7 +44,9 @@ export class DataTableComponent implements OnChanges, OnInit {
   @Input() emptyMsg: any;
   @Input() filterApplied = false;
   @Input() menuItems: any = [];
-
+  @Input() noItemsClass: any = 'background-image: url("/assets/svgs/No_Clients.svg")';
+  @Input() entityTypeName = 'Identities';
+  @Input() showNoItemsAdd = true;
   @Output() actionRequested = new EventEmitter<{ action: string; item?: any }>();
   // @Output() filterChanged = new EventEmitter();
   @Output() gridReady = new EventEmitter();
@@ -343,6 +345,10 @@ export class DataTableComponent implements OnChanges, OnInit {
 
   closeHeaderFilter(event): void {
     this.showFilterOptions = false;
+  }
+
+  openCreate() {
+    this.actionRequested.emit({action: 'create'});
   }
 
   anySelected() {

--- a/projects/open-ziti-console-lib/src/lib/features/list-page-features/list-page-header/list-page-header.component.scss
+++ b/projects/open-ziti-console-lib/src/lib/features/list-page-features/list-page-header/list-page-header.component.scss
@@ -62,11 +62,12 @@
       font-weight: 600;
       cursor: pointer;
       transition: var(--transition);
-    }
-    .tab:hover {
       border-bottom-width: 4px;
-      border-bottom-color: var(--secondary);
+      border-bottom-color: transparent;
       border-bottom-style: solid;
+      &:hover {
+        border-bottom-color: var(--inputBorder);
+      }
     }
   }
 

--- a/projects/open-ziti-console-lib/src/lib/features/no-items/no-items.component.html
+++ b/projects/open-ziti-console-lib/src/lib/features/no-items/no-items.component.html
@@ -1,0 +1,10 @@
+<div [hidden]="!isEmpty" class="noarea" id="NoArea">
+    <div (click)="iconClick()">
+        <div [ngStyle]="background" class="icon"></div>
+        <div class="title">
+            This network currently has no {{ typeName }} to display.<br/><span [hidden]="!hasAdd"
+        >Tap on the <span class="addExample"></span> to add one.</span
+        >
+        </div>
+    </div>
+</div>

--- a/projects/open-ziti-console-lib/src/lib/features/no-items/no-items.component.scss
+++ b/projects/open-ziti-console-lib/src/lib/features/no-items/no-items.component.scss
@@ -1,0 +1,89 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.addExample {
+  display: inline-block;
+  width: 35px;
+  height: 35px;
+  background-image: url(/assets/svgs/No_Plus.svg);
+  background-size: contain;
+  background-repeat: no-repeat;
+  margin-bottom: -8px;
+}
+
+.addExample:hover {
+  filter: brightness(90%);
+  transition: 0.3s;
+}
+
+.addExample:active {
+  filter: brightness(80%);
+  transform: scale(0.97);
+  transition: 0.3s;
+}
+
+@media only screen and (max-width: 715px) {
+  .addExample {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+@media only screen and (max-width: 1500px) {
+  .noarea {
+    transform: scale(0.75);
+  }
+}
+
+@media only screen and (max-width: 1250px) {
+  .noarea {
+    transform: scale(0.6);
+  }
+}
+
+.hidden-results {
+  margin-top: 20px;
+
+  span {
+    font-size: 22px;
+    cursor: default;
+
+    a {
+      cursor: pointer;
+    }
+  }
+}
+
+.no-items-loader-container {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  background: rgba(255, 255, 255, 0.25);
+  z-index: 99999;
+}
+
+::ng-deep .no-items-loader-container #Loading {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 9999;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.title {
+  font-family: "Open Sans";
+  filter: unset;
+  text-align: center;
+  font-size: 24px;
+  color: var(--menu);
+  text-transform: unset;
+}

--- a/projects/open-ziti-console-lib/src/lib/features/no-items/no-items.component.ts
+++ b/projects/open-ziti-console-lib/src/lib/features/no-items/no-items.component.ts
@@ -1,0 +1,31 @@
+import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
+
+@Component({
+  selector: 'lib-no-items',
+  templateUrl: './no-items.component.html',
+  styleUrls: ['./no-items.component.scss'],
+})
+export class NoItemsComponent implements OnChanges {
+  @Input() image = 'No_Gateways';
+  @Input() typeName = '';
+  @Input() isEmpty = false;
+  @Input() hasAdd = true;
+  @Input() hiddenResults = false;
+  @Input() isLoading = false;
+  background;
+  @Output() clickEmit = new EventEmitter<any>();
+  @Output() refresh = new EventEmitter<any>();
+
+  constructor() {
+  }
+
+  ngOnChanges() {
+    this.background = {
+      'background-image': 'url(/assets/svgs/' + this.image + '.svg)',
+    };
+  }
+
+  iconClick() {
+    this.clickEmit.emit();
+  }
+}

--- a/projects/open-ziti-console-lib/src/lib/features/wrappers/zac-wrapper.service.ts
+++ b/projects/open-ziti-console-lib/src/lib/features/wrappers/zac-wrapper.service.ts
@@ -97,7 +97,7 @@ export class ZacWrapperService {
 
     initZac() {
         const appInit = get(window, 'app.init');
-        this.settingsService.settingsChange.subscribe(() => {
+        this.settingsService.settingsChange.subscribe((settings) => {
             if (!this.settingsService.useNodeServer) {
                 set(window, 'service.call', this.handleServiceCall.bind(this));
             } else {
@@ -216,6 +216,11 @@ export class ZacWrapperService {
                     this.page = 'login';
                     route = this.URLS.ZAC_LOGIN;
                     break;
+                case '/organization':
+                case 'organization':
+                    this.page = 'organization';
+                    route = this.URLS.ZITI_CUSTOM_FIELDS;
+                    break;
                 default:
                     this.page = 'index';
                     route = this.URLS.ZITI_DASHBOARD;
@@ -278,6 +283,7 @@ export class ZacWrapperService {
                     case this.URLS.ZITI_POSTURE_CHECKS:
                         this.page = 'posture-checks';
                         break;
+                    case this.URLS.ZITI_BROWZER_CAS:
                     case this.URLS.ZITI_CERT_AUTHORITIES:
                         this.page = 'cas';
                         break;
@@ -292,6 +298,9 @@ export class ZacWrapperService {
                         break;
                     case this.URLS.ZITI_SERVERS:
                         this.page = 'servers';
+                        break;
+                    case this.URLS.ZITI_CUSTOM_FIELDS:
+                        this.page = 'organization';
                         break;
                     default:
                         this.page = 'index';

--- a/projects/open-ziti-console-lib/src/lib/features/wrappers/zac-wrapper.service.ts
+++ b/projects/open-ziti-console-lib/src/lib/features/wrappers/zac-wrapper.service.ts
@@ -97,7 +97,13 @@ export class ZacWrapperService {
 
     initZac() {
         const appInit = get(window, 'app.init');
-        set(window, 'service.call', this.handleServiceCall.bind(this));
+        this.settingsService.settingsChange.subscribe(() => {
+            if (!this.settingsService.useNodeServer) {
+                set(window, 'service.call', this.handleServiceCall.bind(this));
+            } else {
+                set(window, 'service.host', this.settingsService.protocol+"://"+this.settingsService.host+":"+this.settingsService.port);
+            }
+        });
         this.initZacListeners();
     }
 

--- a/projects/open-ziti-console-lib/src/lib/open-ziti-console-lib.module.ts
+++ b/projects/open-ziti-console-lib/src/lib/open-ziti-console-lib.module.ts
@@ -45,6 +45,7 @@ import { ConfirmComponent } from './features/confirm/confirm.component';
 import {onAppInit} from "./app.initializer";
 import {ClickOutsideModule} from "ng-click-outside";
 import {NgJsonEditorModule} from "ang-jsoneditor";
+import { NoItemsComponent } from './features/no-items/no-items.component';
 
 @NgModule({
     declarations: [
@@ -82,6 +83,7 @@ import {NgJsonEditorModule} from "ang-jsoneditor";
         ExtendableComponent,
         GrowlerComponent,
         ConfirmComponent,
+        NoItemsComponent,
     ],
     imports: [
         CommonModule,

--- a/projects/open-ziti-console-lib/src/lib/pages/configurations/configurations-page.component.ts
+++ b/projects/open-ziti-console-lib/src/lib/pages/configurations/configurations-page.component.ts
@@ -24,10 +24,9 @@ export class ConfigurationsPageComponent extends ListPageComponent implements On
     constructor(
         svc: ConfigurationsPageService,
         filterService: DataTableFilterService,
-        settings: SettingsService,
         private tabNames: TabNameService,
     ) {
-        super(filterService, svc, settings);
+        super(filterService, svc);
     }
 
     override ngOnInit() {

--- a/projects/open-ziti-console-lib/src/lib/pages/configurations/configurations-page.component.ts
+++ b/projects/open-ziti-console-lib/src/lib/pages/configurations/configurations-page.component.ts
@@ -4,6 +4,7 @@ import {ConfigurationsPageService} from "./configurations-page.service";
 import {TabNameService} from "../../services/tab-name.service";
 import {ListPageComponent} from "../../shared/list-page-component.class";
 import {CallbackResults} from "../../features/list-page-features/list-page-form/list-page-form.component";
+import {SettingsService} from "../../services/settings.service";
 
 @Component({
     selector: 'lib-configurations',
@@ -23,10 +24,10 @@ export class ConfigurationsPageComponent extends ListPageComponent implements On
     constructor(
         svc: ConfigurationsPageService,
         filterService: DataTableFilterService,
+        settings: SettingsService,
         private tabNames: TabNameService,
-
     ) {
-        super(filterService, svc);
+        super(filterService, svc, settings);
     }
 
     override ngOnInit() {

--- a/projects/open-ziti-console-lib/src/lib/pages/configurations/configurations-page.service.ts
+++ b/projects/open-ziti-console-lib/src/lib/pages/configurations/configurations-page.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {FilterObj} from "../../features/data-table/data-table-filter.service";
+import {DataTableFilterService, FilterObj} from "../../features/data-table/data-table-filter.service";
 import _, {isEmpty} from "lodash";
 import moment from "moment";
 import {ListPageServiceClass} from "../../shared/list-page-service.class";
@@ -8,6 +8,7 @@ import {
 } from "../../features/data-table/column-headers/table-column-default/table-column-default.component";
 import {CallbackResults} from "../../features/list-page-features/list-page-form/list-page-form.component";
 import {SchemaService} from "../../services/schema.service";
+import {SettingsService} from "../../services/settings.service";
 
 @Injectable({
     providedIn: 'root'
@@ -16,8 +17,8 @@ export class ConfigurationsPageService extends ListPageServiceClass {
 
     private paging = this.DEFAULT_PAGING;
 
-    constructor(private schemaSvc: SchemaService) {
-        super();
+    constructor(private schemaSvc: SchemaService, settings: SettingsService, filterService: DataTableFilterService) {
+        super(settings, filterService);
     }
 
     initTableColumns(): any {

--- a/projects/open-ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
+++ b/projects/open-ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
@@ -27,12 +27,11 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
   constructor(
       svc: IdentitiesPageService,
       filterService: DataTableFilterService,
-      settings: SettingsService,
       public dialogForm: MatDialog,
       private tabNames: TabNameService,
       @Inject(ZAC_WRAPPER_SERVICE)private zacWrapperService: ZacWrapperService
   ) {
-    super(filterService, svc, settings);
+    super(filterService, svc);
   }
 
   override ngOnInit() {

--- a/projects/open-ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
+++ b/projects/open-ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
@@ -10,6 +10,7 @@ import $ from 'jquery';
 import {ConfirmComponent} from "../../features/confirm/confirm.component";
 import {MatDialog} from "@angular/material/dialog";
 import {ZAC_WRAPPER_SERVICE, ZacWrapperService} from "../../features/wrappers/zac-wrapper.service";
+import {SettingsService} from "../../services/settings.service";
 
 @Component({
   selector: 'lib-identities',
@@ -26,11 +27,12 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
   constructor(
       svc: IdentitiesPageService,
       filterService: DataTableFilterService,
+      settings: SettingsService,
       public dialogForm: MatDialog,
       private tabNames: TabNameService,
       @Inject(ZAC_WRAPPER_SERVICE)private zacWrapperService: ZacWrapperService
   ) {
-    super(filterService, svc);
+    super(filterService, svc, settings);
   }
 
   override ngOnInit() {
@@ -102,6 +104,9 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
         break;
       case 'update':
         this.editItem(event.item)
+        break;
+      case 'create':
+        this.openUpdate()
         break;
       case 'override':
         this.getOverrides(event.item)

--- a/projects/open-ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
+++ b/projects/open-ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
@@ -1,12 +1,13 @@
 import {Injectable} from "@angular/core";
 import {isEmpty} from 'lodash';
 import moment from 'moment';
-import {FilterObj} from "../../features/data-table/data-table-filter.service";
+import {DataTableFilterService, FilterObj} from "../../features/data-table/data-table-filter.service";
 import {ListPageServiceClass} from "../../shared/list-page-service.class";
 import {
     TableColumnDefaultComponent
 } from "../../features/data-table/column-headers/table-column-default/table-column-default.component";
 import {CallbackResults} from "../../features/list-page-features/list-page-form/list-page-form.component";
+import {SettingsService} from "../../services/settings.service";
 
 @Injectable({
     providedIn: 'root'
@@ -29,8 +30,8 @@ export class IdentitiesPageService extends ListPageServiceClass {
         {name: 'Delete', action: 'delete'},
     ]
 
-    constructor() {
-        super();
+    constructor(settings: SettingsService, filterService: DataTableFilterService) {
+        super(settings, filterService);
     }
 
     validate = (formData): Promise<CallbackResults> => {

--- a/projects/open-ziti-console-lib/src/lib/services/settings.service.ts
+++ b/projects/open-ziti-console-lib/src/lib/services/settings.service.ts
@@ -12,6 +12,8 @@ const DEFAULTS = {
     "editable": true,
     "update": false,
     "location": "../ziti",
+    "protocol": "http",
+    "host": "localhost",
     "port": 1408,
     "portTLS": 8443,
     "rejectUnauthorized": false,
@@ -25,7 +27,8 @@ const DEFAULTS = {
         }
     },
     "from": "",
-    "to": ""
+    "to": "",
+    "useNodeServer": true
 }
 
 @Injectable({
@@ -41,6 +44,9 @@ export class SettingsService {
     port = DEFAULTS.port;
     portTLS = DEFAULTS.portTLS;
     apiVersions: any[] = [];
+    useNodeServer = DEFAULTS.useNodeServer;
+    protocol = DEFAULTS.protocol;
+    host = DEFAULTS.host;
 
     constructor(private httpClient: HttpClient) {
     }

--- a/projects/open-ziti-console-lib/src/lib/shared/list-page-component.class.ts
+++ b/projects/open-ziti-console-lib/src/lib/shared/list-page-component.class.ts
@@ -1,9 +1,6 @@
 import {DataTableFilterService} from "../features/data-table/data-table-filter.service";
 import {ListPageServiceClass} from "./list-page-service.class";
 import {Injectable} from "@angular/core";
-import {SettingsService} from "../services/settings.service";
-
-import {isEmpty} from "lodash";
 
 @Injectable()
 export abstract class ListPageComponent {
@@ -19,12 +16,10 @@ export abstract class ListPageComponent {
     columnDefs: any = [];
     rowData = [];
     filterApplied = false;
-    sessionId = '';
 
     constructor(
         protected filterService: DataTableFilterService,
-        protected svc: ListPageServiceClass,
-        protected settings: SettingsService,
+        protected svc: ListPageServiceClass
     ) {}
 
     ngOnInit() {
@@ -34,14 +29,6 @@ export abstract class ListPageComponent {
         this.filterService.filtersChanged.subscribe(filters => {
             this.filterApplied = filters && filters.length > 0;
             this.refreshData();
-        });
-        this.settings.settingsChange.subscribe((settings) => {
-            if (!isEmpty(this.settings?.settings?.session?.id)) {
-                if (this.sessionId !== this.settings?.settings?.session?.id) {
-                    this.refreshData();
-                    this.sessionId = this.settings?.settings?.session?.id
-                }
-            }
         });
     }
 

--- a/projects/open-ziti-console-lib/src/lib/shared/list-page-component.class.ts
+++ b/projects/open-ziti-console-lib/src/lib/shared/list-page-component.class.ts
@@ -1,6 +1,9 @@
 import {DataTableFilterService} from "../features/data-table/data-table-filter.service";
 import {ListPageServiceClass} from "./list-page-service.class";
 import {Injectable} from "@angular/core";
+import {SettingsService} from "../services/settings.service";
+
+import {isEmpty} from "lodash";
 
 @Injectable()
 export abstract class ListPageComponent {
@@ -16,10 +19,12 @@ export abstract class ListPageComponent {
     columnDefs: any = [];
     rowData = [];
     filterApplied = false;
+    sessionId = '';
 
     constructor(
         protected filterService: DataTableFilterService,
-        protected svc: ListPageServiceClass
+        protected svc: ListPageServiceClass,
+        protected settings: SettingsService,
     ) {}
 
     ngOnInit() {
@@ -29,6 +34,14 @@ export abstract class ListPageComponent {
         this.filterService.filtersChanged.subscribe(filters => {
             this.filterApplied = filters && filters.length > 0;
             this.refreshData();
+        });
+        this.settings.settingsChange.subscribe((settings) => {
+            if (!isEmpty(this.settings?.settings?.session?.id)) {
+                if (this.sessionId !== this.settings?.settings?.session?.id) {
+                    this.refreshData();
+                    this.sessionId = this.settings?.settings?.session?.id
+                }
+            }
         });
     }
 

--- a/projects/open-ziti-console-lib/src/lib/shared/list-page-service.class.ts
+++ b/projects/open-ziti-console-lib/src/lib/shared/list-page-service.class.ts
@@ -1,10 +1,13 @@
 import {inject} from '@angular/core';
 import {ZitiDataService} from "../services/ziti-data.service";
-import {FilterObj} from "../features/data-table/data-table-filter.service";
+import {DataTableFilterService, FilterObj} from "../features/data-table/data-table-filter.service";
 import {ValidatorCallback} from "../features/list-page-features/list-page-form/list-page-form.component";
 import {DialogRef} from "@angular/cdk/dialog";
 import {MatDialog} from "@angular/material/dialog";
 import {ConfirmComponent} from "../features/confirm/confirm.component";
+import {SettingsService} from "../services/settings.service";
+
+import {isEmpty} from "lodash";
 
 export abstract class ListPageServiceClass {
 
@@ -27,14 +30,22 @@ export abstract class ListPageServiceClass {
         total: 100
     }
     dataService: ZitiDataService;
-    refreshData: (sort: {sortBy: string, ordering: string}) => void | undefined;
+    refreshData: (sort?: {sortBy: string, ordering: string}) => void | undefined;
 
     menuItems: any = [];
-
+    currentSettings: any = {};
     dialogRef: any;
 
-    constructor() {
+    constructor(protected settings: SettingsService, protected filterService: DataTableFilterService) {
         this.dataService = inject(ZitiDataService);
+        this.settings.settingsChange.subscribe((settings) => {
+            if (!isEmpty(this.settings?.settings?.session?.id)) {
+                if (this.currentSettings?.session?.id !== settings?.session?.id) {
+                    this.refreshData();
+                    this.currentSettings = settings
+                }
+            }
+        });
     }
 
     getTableData(resourceType: string, paging: any, filters?: FilterObj[], sort?: any): Promise<any> {

--- a/projects/open-ziti-console-lib/src/lib/urls.ts
+++ b/projects/open-ziti-console-lib/src/lib/urls.ts
@@ -15,6 +15,7 @@ export const URLS = {
   ZITI_ROUTER_POLICIES: '/router-policies',
   ZITI_SERVICE_ROUTER_POLICIES: '/service-router-policies',
   ZITI_POSTURE_CHECKS: '/posture-checks',
+  ZITI_BROWZER_CAS: '/browzer-cert-auth',
   ZITI_CERT_AUTHORITIES: '/certificate-authorities',
   ZITI_SESSIONS: '/sessions',
   ZITI_LOGIN: '/login',
@@ -22,5 +23,6 @@ export const URLS = {
   ZITI_PROFILE: '/profile',
   ZITI_SERVERS: '/servers',
   ZITI_SETTINGS: '/settings',
+  ZITI_CUSTOM_FIELDS: '/custom-fields',
   ZAC_LOGIN: '/login',
 };


### PR DESCRIPTION
* Added mapping for additional ZAC pages/routes
* Fix refresh of list page when current selected edge controller is updated
* Added new "No Items" component for display when list table is empty
* Fox highlighting of selected/hovered navigation sub-tab's

Made updates from previous review:

* Added `<ng-template>` back into data-table.component
* Moved data refresh on controller change out of list-table.component and into list-page.service